### PR TITLE
Some upgrade

### DIFF
--- a/Android/app/src/main/java/com/example/androidMic/ui/States.kt
+++ b/Android/app/src/main/java/com/example/androidMic/ui/States.kt
@@ -81,7 +81,8 @@ enum class SampleRates(val value: Int) {
 enum class AudioFormat(val value: Int) {
     I16(1),
     I24(3),
-    I32(4)
+    I32(4),
+    F32(2)
 }
 
 enum class ChannelCount(val value: Int) {

--- a/android-mic-rs/Cargo.lock
+++ b/android-mic-rs/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 name = "android-mic-rs"
 version = "0.1.0"
 dependencies = [
- "byteorder",
+ "byteordered",
  "clap",
  "cpal",
  "crossterm",
@@ -143,6 +143,15 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "byteordered"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf2cd9424f5ff404aba1959c835cbc448ee8b689b870a9981c76c0fd46280e6"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "bytes"

--- a/android-mic-rs/Cargo.toml
+++ b/android-mic-rs/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 cpal = "0.15.2"
-byteorder = "1.4.3"
+byteordered = "0.6.0"
 rtrb = "0.2.3"
 crossterm = {version = "0.27.0"}
 clap = { version = "4.3.19", features = ["derive"] }

--- a/android-mic-rs/README.md
+++ b/android-mic-rs/README.md
@@ -12,7 +12,7 @@ how to build
 - install rust: https://www.rust-lang.org/tools/install
 
 ```shell
-cargo run --release
+cargo build --release
 ```
 
 
@@ -49,13 +49,13 @@ Options:
 ```
 
 example:
-```
-cargo run --release -- --ip 192.168.1.79 -m UDP
+```shell
+./target/release/android-mic-rs.exe --ip 192.168.1.79 -m UDP
 ```
 
 
 advanced:
-```
+```shell
 clear && cargo run --release -- --ip 192.168.1.79 --mode UDP --channel 2 -f i16 --device 4
 ```
 

--- a/android-mic-rs/README.md
+++ b/android-mic-rs/README.md
@@ -66,5 +66,5 @@ todo:
 - stereo: implemented but have bugs
 - parse ipv4/v6: done, no support for v6 tho
 - release socket if necesseray: not needed i think
-- stop audio when disconnect 
+- detect TCP disconnect 
 - try ASIO backend

--- a/android-mic-rs/README.md
+++ b/android-mic-rs/README.md
@@ -60,11 +60,11 @@ clear && cargo run --release -- --ip 192.168.1.79 --mode UDP --channel 2 -f i16 
 ```
 
 todo: 
-- support multiple audio format: done but not tested
+- support multiple audio format: done but have bugs
 - support multiple sample: done but not tested
 - choose output device: done
 - stereo: implemented but have bugs
 - parse ipv4/v6: done, no support for v6 tho
 - release socket if necesseray: not needed i think
-- detect TCP disconnect 
+- detect TCP disconnect: Done
 - try ASIO backend

--- a/android-mic-rs/src/audio.rs
+++ b/android-mic-rs/src/audio.rs
@@ -74,14 +74,28 @@ pub fn setup_audio(consumer: Consumer<u8>, args: &Args) -> Result<cpal::Stream, 
 
     println!();
     println!("Audio config:");
+    println!("- selected device: {}", args.output_device);
     println!("- number of channel: {}", config.channels);
     println!("- sample rate: {}", config.sample_rate.0);
     println!("- buffer size: {:?}", config.buffer_size);
+    println!("- audio format: {}", args.audio_format);
     println!();
 
     match args.audio_format {
         AudioFormat::I16 => build::<i16>(&device, &config, consumer, channel_strategy),
         AudioFormat::I32 => build::<i32>(&device, &config, consumer, channel_strategy),
+        AudioFormat::I8 => todo!(),
+        AudioFormat::I24 => todo!(),
+        AudioFormat::I48 => todo!(),
+        AudioFormat::I64 => todo!(),
+        AudioFormat::U8 => todo!(),
+        AudioFormat::U16 => todo!(),
+        AudioFormat::U24 => todo!(),
+        AudioFormat::U32 => todo!(),
+        AudioFormat::U48 => todo!(),
+        AudioFormat::U64 => todo!(),
+        AudioFormat::F32 => build::<f32>(&device, &config, consumer, channel_strategy),
+        AudioFormat::F64 => todo!(),
     }
 }
 
@@ -182,6 +196,28 @@ impl Format for i32 {
 
         let mut cursor: Cursor<Vec<u8>> = Cursor::new(vec![byte1, byte2, byte3, byte4]);
         Some(cursor.read_i32::<LittleEndian>().unwrap())
+    }
+}
+
+// not tested
+impl Format for f32 {
+    fn from_chunk(chunk: &mut ReadChunkIntoIter<'_, u8>) -> Option<Self> {
+        let Some(byte1) = chunk.next()  else {
+            return None;
+        };
+        let Some(byte2) = chunk.next()  else {
+            return None;
+        };
+
+        let Some(byte3) = chunk.next()  else {
+            return None;
+        };
+        let Some(byte4) = chunk.next()  else {
+            return None;
+        };
+
+        let mut cursor: Cursor<Vec<u8>> = Cursor::new(vec![byte1, byte2, byte3, byte4]);
+        Some(cursor.read_f32::<LittleEndian>().unwrap())
     }
 }
 

--- a/android-mic-rs/src/main.rs
+++ b/android-mic-rs/src/main.rs
@@ -1,4 +1,8 @@
 #![allow(dead_code)]
+use byteordered::{
+    byteorder::{BigEndian, LittleEndian},
+    Endianness,
+};
 use clap::Parser;
 use cpal::traits::StreamTrait;
 use rtrb::RingBuffer;
@@ -40,10 +44,13 @@ fn main() {
 
     let mut app = App::new();
 
-    // Buffer to store received data
     let (producer, consumer) = RingBuffer::<u8>::new(SHARED_BUF_SIZE);
 
-    match setup_audio(consumer, &args) {
+    let audio_stream_builder = match Endianness::native() {
+        Endianness::Little => setup_audio::<LittleEndian>(consumer, &args),
+        Endianness::Big => setup_audio::<BigEndian>(consumer, &args),
+    };
+    match audio_stream_builder {
         Err(e) => {
             eprintln!("{:?}", e);
             return;

--- a/android-mic-rs/src/user_action.rs
+++ b/android-mic-rs/src/user_action.rs
@@ -42,7 +42,7 @@ pub struct Args {
     #[arg(short = 'm', long = "mode", id = "connection mode", help = "UDP or TCP", default_value_t = ConnectionMode::Udp)]
     pub connection_mode: ConnectionMode,
 
-    #[arg(short = 'f', long = "format", id = "audio format",  help = "i16 or i32", default_value_t = AudioFormat::I16)]
+    #[arg(short = 'f', long = "format", id = "audio format",  help = "i16, f32, ...", default_value_t = AudioFormat::I16)]
     pub audio_format: AudioFormat,
 
     #[arg(
@@ -94,8 +94,35 @@ pub enum ChannelCount {
 
 #[derive(Debug, Clone, EnumString, PartialEq, Display)]
 pub enum AudioFormat {
+    #[strum(serialize = "i8")]
+    I8,
     #[strum(serialize = "i16")]
     I16,
+    #[strum(serialize = "i24")]
+    I24,
     #[strum(serialize = "i32")]
     I32,
+    #[strum(serialize = "i48")]
+    I48,
+    #[strum(serialize = "i64")]
+    I64,
+
+    
+    #[strum(serialize = "u8")]
+    U8,
+    #[strum(serialize = "u16")]
+    U16,
+    #[strum(serialize = "u24")]
+    U24,
+    #[strum(serialize = "u32")]
+    U32,
+    #[strum(serialize = "u48")]
+    U48,
+    #[strum(serialize = "u64")]
+    U64,
+
+    #[strum(serialize = "f32")]
+    F32,
+    #[strum(serialize = "f64")]
+    F64,
 }

--- a/android-mic-rs/src/user_action.rs
+++ b/android-mic-rs/src/user_action.rs
@@ -107,7 +107,6 @@ pub enum AudioFormat {
     #[strum(serialize = "i64")]
     I64,
 
-    
     #[strum(serialize = "u8")]
     U8,
     #[strum(serialize = "u16")]


### PR DESCRIPTION
this should add endianess support at runtime.

it also fix a bug with TCP connection. i'm practically sure that is the same bug i encounter on Windows  #21.
it happens when android disconnect. The server will read a buffer with nothing in it infinitely.

Also, there is a lot a things witch don't works
- audio format, only i16 works on my machine
- stereo

And sound on Linux not work anymore :sob: 
But it worked at some point: 82192c0aa15e61e5a58aac595ec96bbbe67951ac.

that make me thinks: why it work on Windows ?
Let's say you record with i16 format. You send values using u8 bytes.
On server side, you read 2 bytes and make an i16 from it.
But what prevent you of taking 2 bytes which do not form the same value?
- value1 = [byte1, byte2]
- value2 = [byte3, byte4]

and then
value = [byte2, byte3]

Same for stereo, i guess i will have to look some docs at some point...
But this weird that work on Windows. idk if this what you meant in this
> I see haha maybe it just works because the packets carry the circular buffer offsets so they already have that ordering info. 