### PR TITLE
Assume mono audio on android side

### DIFF
--- a/android-mic-rs/src/audio.rs
+++ b/android-mic-rs/src/audio.rs
@@ -318,10 +318,11 @@ impl ChannelStrategy {
             ChannelStrategy::Stereo => {
                 if let Some(value) = F::produce_value_from_chunk::<E>(chunk) {
                     frame[0] = value;
-                }
-                if let Some(value) = F::produce_value_from_chunk::<E>(chunk) {
                     frame[1] = value;
                 }
+                // if let Some(value) = F::produce_value_from_chunk::<E>(chunk) {
+                //     frame[1] = value;
+                // }
             }
             ChannelStrategy::MonoCloned => {
                 if let Some(value) = F::produce_value_from_chunk::<E>(chunk) {


### PR DESCRIPTION
I've played with the rust server and modified a few things. My opinion is that there are too many choices:
* The audio player has channel, format, sample rate options
* The server has channel, format, sample rate options
* The app has channel, format, sample rate options

I'd suggest we use `mono, 16000, i16` for the app and do not offer options to change them.
And on rust server we can always resample up to 48000 stereo.

Btw this pull request is just a fix for my device. I'm using 48000, mono, i16 on the app, and 48000, stereo, i16 for the rust server, and my audio device is 48000, stereo, f32.

Didn't see any issue with data order or formats. And yes UDP is super fast.

@wiiznokes 