### PR TITLE
Automated Binary Build & Release via GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,174 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-all:
+    name: Build All Platforms
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: windows-latest
+            platform: windows
+          - os: macos-latest
+            platform: macos
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies (Linux)
+        if: matrix.platform == 'linux'
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libjack-jackd2-dev libxkbcommon-dev protobuf-compiler
+
+      - name: Install dependencies (Windows)
+        if: matrix.platform == 'windows'
+        run: choco install protoc
+
+      - name: Install dependencies (macOS)
+        if: matrix.platform == 'macos'
+        run: brew install protobuf
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./RustApp -> target"
+          
+      - name: Install cargo-packager
+        if: matrix.platform == 'windows' || matrix.platform == 'macos'
+        run: cargo install cargo-packager
+        
+      - name: Build (Linux)
+        if: matrix.platform == 'linux'
+        working-directory: ./RustApp
+        run: cargo build --release
+        
+      - name: Package (Windows/macOS)
+        if: matrix.platform == 'windows' || matrix.platform == 'macos'
+        working-directory: ./RustApp
+        run: |
+          # Debug what cargo-packager is doing
+          echo "Running cargo packager with verbose output"
+          cargo packager --release -v
+        
+      - name: Debug output directory structure
+        shell: bash
+        run: |
+          echo "Listing target directory structure"
+          find ./RustApp/target -type f -not -path "*/deps/*" -not -path "*/examples/*" -not -path "*/incremental/*" | sort
+          
+      # For Linux
+      - name: Upload Linux binary
+        if: matrix.platform == 'linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: androidmic-linux
+          path: ./RustApp/target/release/android-mic
+          if-no-files-found: warn
+          
+      # For Windows
+      - name: Upload Windows built files
+        if: matrix.platform == 'windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: androidmic-windows
+          path: |
+            ./RustApp/target/release/android-mic.exe
+            ./RustApp/target/release/bundles/**/*
+          if-no-files-found: warn
+          
+      # For macOS
+      - name: Upload macOS built files
+        if: matrix.platform == 'macos'
+        uses: actions/upload-artifact@v4
+        with:
+          name: androidmic-macos
+          path: |
+            ./RustApp/target/release/android-mic
+            ./RustApp/target/release/bundles/**/*
+          if-no-files-found: warn
+
+  build-android:
+    name: Build Android
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        working-directory: ./Android
+        run: chmod +x gradlew
+
+      - name: Build Release APK
+        working-directory: ./Android
+        run: ./gradlew assembleRelease
+        
+      - name: List APK files
+        working-directory: ./Android
+        run: find app/build/outputs -name "*.apk"
+        
+      - name: Upload Android APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: androidmic-android-apk
+          path: ./Android/app/build/outputs/apk/release/*.apk
+          if-no-files-found: warn
+
+  create-release:
+    name: Create GitHub Release
+    needs: [build-all, build-android]
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: all-artifacts
+          
+      - name: Display structure of downloaded files
+        run: find all-artifacts -type f | sort
+        
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          draft: true
+          generate_release_notes: true
+          files: all-artifacts/**/*
+          body: |
+            ## AndroidMic ${{ github.ref_name }}
+            
+            ### What's Changed
+            <!-- You can add manual notes here, they will be combined with automated notes -->
+            
+            ### Installation
+            - For Windows: Download and run the .msi installer
+            - For Linux: Install the .deb package
+            - For macOS: Download and open the .dmg file
+            - For Android: Install the .apk file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,9 +166,9 @@ jobs:
             
             ### What's Changed
             <!-- You can add manual notes here, they will be combined with automated notes -->
+             - Several improvements and bug fixed
             
             ### Installation
-            - For Windows: Download and run the .msi installer
-            - For Linux: Install the .deb package
-            - For macOS: Download and open the .dmg file
-            - For Android: Install the .apk file
+            - For Android: Install the `.apk` file
+            - For Linux: Install the `android-mic` binary
+            - For Windows: Download and run the `.exe`

--- a/Project_Tree.txt
+++ b/Project_Tree.txt
@@ -4,141 +4,18 @@ Project Root
 |   Project_Tree.txt
 |   README.md
 |   
++---.github
+|   \---workflows
+|           release.yml
+|           
 +---Android
 |   |   .gitignore
 |   |   build.gradle.kts
 |   |   gradle.properties
 |   |   gradlew
 |   |   gradlew.bat
-|   |   local.properties
 |   |   settings.gradle.kts
 |   |   
-|   +---.gradle
-|   |   |   config.properties
-|   |   |   file-system.probe
-|   |   |   
-|   |   +---8.10.2
-|   |   |   |   gc.properties
-|   |   |   |   
-|   |   |   +---checksums
-|   |   |   |       checksums.lock
-|   |   |   |       md5-checksums.bin
-|   |   |   |       sha1-checksums.bin
-|   |   |   |       
-|   |   |   +---dependencies-accessors
-|   |   |   |   |   gc.properties
-|   |   |   |   |   
-|   |   |   |   \---16470e2c74a9bdeb32952e81daa7fce3a9a172cd
-|   |   |   |       |   metadata.bin
-|   |   |   |       |   
-|   |   |   |       +---classes
-|   |   |   |       |   \---org
-|   |   |   |       |       \---gradle
-|   |   |   |       |           \---accessors
-|   |   |   |       |               \---dm
-|   |   |   |       |                       LibrariesForLibs$AccompanistLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$AndroidPluginAccessors.class
-|   |   |   |       |                       LibrariesForLibs$AndroidxLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$AndroidxUiLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$AndroidxViewmodelLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$BundleAccessors.class
-|   |   |   |       |                       LibrariesForLibs$ComposeLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$ComposeMaterialIconsLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$ComposeMaterialLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$ComposePluginAccessors.class
-|   |   |   |       |                       LibrariesForLibs$ComposeUiLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$DatastoreLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$GooglePluginAccessors.class
-|   |   |   |       |                       LibrariesForLibs$KotlinPluginAccessors.class
-|   |   |   |       |                       LibrariesForLibs$KotlinxCoroutinesLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$KotlinxLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$KtxVersionAccessors.class
-|   |   |   |       |                       LibrariesForLibs$PluginAccessors.class
-|   |   |   |       |                       LibrariesForLibs$ProtobufGradleLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$ProtobufJavaLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$ProtobufLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$ProtobufVersionAccessors.class
-|   |   |   |       |                       LibrariesForLibs$RuntimeLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$TestJunitLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$TestLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibs$VersionAccessors.class
-|   |   |   |       |                       LibrariesForLibs.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$AccompanistLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$AndroidPluginAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$AndroidxLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$AndroidxUiLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$AndroidxViewmodelLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$BundleAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ComposeLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ComposeMaterialIconsLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ComposeMaterialLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ComposePluginAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ComposeUiLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$DatastoreLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$GooglePluginAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$KotlinPluginAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$KotlinxCoroutinesLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$KotlinxLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$KtxVersionAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$PluginAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ProtobufGradleLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ProtobufJavaLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ProtobufLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ProtobufVersionAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$RuntimeLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$TestJunitLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$TestLibraryAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock$VersionAccessors.class
-|   |   |   |       |                       LibrariesForLibsInPluginsBlock.class
-|   |   |   |       |                       
-|   |   |   |       \---sources
-|   |   |   |           \---org
-|   |   |   |               \---gradle
-|   |   |   |                   \---accessors
-|   |   |   |                       \---dm
-|   |   |   |                               LibrariesForLibs.java
-|   |   |   |                               LibrariesForLibsInPluginsBlock.java
-|   |   |   |                               
-|   |   |   +---executionHistory
-|   |   |   |       executionHistory.lock
-|   |   |   |       
-|   |   |   +---expanded
-|   |   |   +---fileChanges
-|   |   |   |       last-build.bin
-|   |   |   |       
-|   |   |   +---fileHashes
-|   |   |   |       fileHashes.bin
-|   |   |   |       fileHashes.lock
-|   |   |   |       resourceHashesCache.bin
-|   |   |   |       
-|   |   |   \---vcsMetadata
-|   |   +---buildOutputCleanup
-|   |   |       buildOutputCleanup.lock
-|   |   |       cache.properties
-|   |   |       
-|   |   \---vcs-1
-|   |           gc.properties
-|   |           
-|   +---.idea
-|   |   |   .gitignore
-|   |   |   .name
-|   |   |   compiler.xml
-|   |   |   deploymentTargetSelector.xml
-|   |   |   gradle.xml
-|   |   |   kotlinc.xml
-|   |   |   migrations.xml
-|   |   |   misc.xml
-|   |   |   runConfigurations.xml
-|   |   |   vcs.xml
-|   |   |   workspace.xml
-|   |   |   
-|   |   +---caches
-|   |   |       deviceStreaming.xml
-|   |   |       
-|   |   \---codeStyles
-|   |           codeStyleConfig.xml
-|   |           Project.xml
-|   |           
 |   +---app
 |   |   |   .gitignore
 |   |   |   build.gradle.kts

--- a/Project_Tree.txt
+++ b/Project_Tree.txt
@@ -1,0 +1,360 @@
+Project Root 
+|   .gitignore
+|   LICENSE
+|   Project_Tree.txt
+|   README.md
+|   
++---Android
+|   |   .gitignore
+|   |   build.gradle.kts
+|   |   gradle.properties
+|   |   gradlew
+|   |   gradlew.bat
+|   |   local.properties
+|   |   settings.gradle.kts
+|   |   
+|   +---.gradle
+|   |   |   config.properties
+|   |   |   file-system.probe
+|   |   |   
+|   |   +---8.10.2
+|   |   |   |   gc.properties
+|   |   |   |   
+|   |   |   +---checksums
+|   |   |   |       checksums.lock
+|   |   |   |       md5-checksums.bin
+|   |   |   |       sha1-checksums.bin
+|   |   |   |       
+|   |   |   +---dependencies-accessors
+|   |   |   |   |   gc.properties
+|   |   |   |   |   
+|   |   |   |   \---16470e2c74a9bdeb32952e81daa7fce3a9a172cd
+|   |   |   |       |   metadata.bin
+|   |   |   |       |   
+|   |   |   |       +---classes
+|   |   |   |       |   \---org
+|   |   |   |       |       \---gradle
+|   |   |   |       |           \---accessors
+|   |   |   |       |               \---dm
+|   |   |   |       |                       LibrariesForLibs$AccompanistLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$AndroidPluginAccessors.class
+|   |   |   |       |                       LibrariesForLibs$AndroidxLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$AndroidxUiLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$AndroidxViewmodelLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$BundleAccessors.class
+|   |   |   |       |                       LibrariesForLibs$ComposeLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$ComposeMaterialIconsLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$ComposeMaterialLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$ComposePluginAccessors.class
+|   |   |   |       |                       LibrariesForLibs$ComposeUiLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$DatastoreLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$GooglePluginAccessors.class
+|   |   |   |       |                       LibrariesForLibs$KotlinPluginAccessors.class
+|   |   |   |       |                       LibrariesForLibs$KotlinxCoroutinesLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$KotlinxLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$KtxVersionAccessors.class
+|   |   |   |       |                       LibrariesForLibs$PluginAccessors.class
+|   |   |   |       |                       LibrariesForLibs$ProtobufGradleLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$ProtobufJavaLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$ProtobufLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$ProtobufVersionAccessors.class
+|   |   |   |       |                       LibrariesForLibs$RuntimeLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$TestJunitLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$TestLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibs$VersionAccessors.class
+|   |   |   |       |                       LibrariesForLibs.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$AccompanistLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$AndroidPluginAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$AndroidxLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$AndroidxUiLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$AndroidxViewmodelLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$BundleAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ComposeLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ComposeMaterialIconsLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ComposeMaterialLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ComposePluginAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ComposeUiLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$DatastoreLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$GooglePluginAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$KotlinPluginAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$KotlinxCoroutinesLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$KotlinxLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$KtxVersionAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$PluginAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ProtobufGradleLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ProtobufJavaLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ProtobufLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$ProtobufVersionAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$RuntimeLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$TestJunitLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$TestLibraryAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock$VersionAccessors.class
+|   |   |   |       |                       LibrariesForLibsInPluginsBlock.class
+|   |   |   |       |                       
+|   |   |   |       \---sources
+|   |   |   |           \---org
+|   |   |   |               \---gradle
+|   |   |   |                   \---accessors
+|   |   |   |                       \---dm
+|   |   |   |                               LibrariesForLibs.java
+|   |   |   |                               LibrariesForLibsInPluginsBlock.java
+|   |   |   |                               
+|   |   |   +---executionHistory
+|   |   |   |       executionHistory.lock
+|   |   |   |       
+|   |   |   +---expanded
+|   |   |   +---fileChanges
+|   |   |   |       last-build.bin
+|   |   |   |       
+|   |   |   +---fileHashes
+|   |   |   |       fileHashes.bin
+|   |   |   |       fileHashes.lock
+|   |   |   |       resourceHashesCache.bin
+|   |   |   |       
+|   |   |   \---vcsMetadata
+|   |   +---buildOutputCleanup
+|   |   |       buildOutputCleanup.lock
+|   |   |       cache.properties
+|   |   |       
+|   |   \---vcs-1
+|   |           gc.properties
+|   |           
+|   +---.idea
+|   |   |   .gitignore
+|   |   |   .name
+|   |   |   compiler.xml
+|   |   |   deploymentTargetSelector.xml
+|   |   |   gradle.xml
+|   |   |   kotlinc.xml
+|   |   |   migrations.xml
+|   |   |   misc.xml
+|   |   |   runConfigurations.xml
+|   |   |   vcs.xml
+|   |   |   workspace.xml
+|   |   |   
+|   |   +---caches
+|   |   |       deviceStreaming.xml
+|   |   |       
+|   |   \---codeStyles
+|   |           codeStyleConfig.xml
+|   |           Project.xml
+|   |           
+|   +---app
+|   |   |   .gitignore
+|   |   |   build.gradle.kts
+|   |   |   proguard-rules.pro
+|   |   |   
+|   |   \---src
+|   |       +---debug
+|   |       |   \---res
+|   |       |       \---values
+|   |       |               strings.xml
+|   |       |               
+|   |       +---main
+|   |       |   |   AndroidManifest.xml
+|   |       |   |   ic_launcher-playstore.png
+|   |       |   |   
+|   |       |   +---java
+|   |       |   |   \---com
+|   |       |   |       \---example
+|   |       |   |           \---androidMic
+|   |       |   |               |   AndroidMicApp.kt
+|   |       |   |               |   AppModule.kt
+|   |       |   |               |   Preferences.kt
+|   |       |   |               |   
+|   |       |   |               +---domain
+|   |       |   |               |   +---audio
+|   |       |   |               |   |       MicAudioManager.kt
+|   |       |   |               |   |       
+|   |       |   |               |   +---service
+|   |       |   |               |   |       Command.kt
+|   |       |   |               |   |       ForegroundService.kt
+|   |       |   |               |   |       Packets.kt
+|   |       |   |               |   |       ServiceUtil.kt
+|   |       |   |               |   |       
+|   |       |   |               |   \---streaming
+|   |       |   |               |           AdbStreamer.kt
+|   |       |   |               |           BluetoothStreamer.kt
+|   |       |   |               |           MicStreamManager.kt
+|   |       |   |               |           Streamer.kt
+|   |       |   |               |           UdpStreamer.kt
+|   |       |   |               |           UsbStreamer.kt
+|   |       |   |               |           WifiStreamer.kt
+|   |       |   |               |           
+|   |       |   |               +---ui
+|   |       |   |               |   |   MainActivity.kt
+|   |       |   |               |   |   MainViewModel.kt
+|   |       |   |               |   |   
+|   |       |   |               |   +---components
+|   |       |   |               |   |       Components.kt
+|   |       |   |               |   |       
+|   |       |   |               |   +---home
+|   |       |   |               |   |   |   AppBar.kt
+|   |       |   |               |   |   |   HomeScreen.kt
+|   |       |   |               |   |   |   NavigationDrawer.kt
+|   |       |   |               |   |   |   
+|   |       |   |               |   |   \---dialog
+|   |       |   |               |   |           audio.kt
+|   |       |   |               |   |           BaseDialog.kt
+|   |       |   |               |   |           ipPort.kt
+|   |       |   |               |   |           mode.kt
+|   |       |   |               |   |           theme.kt
+|   |       |   |               |   |           
+|   |       |   |               |   +---theme
+|   |       |   |               |   |       Color.kt
+|   |       |   |               |   |       Theme.kt
+|   |       |   |               |   |       Type.kt
+|   |       |   |               |   |       
+|   |       |   |               |   \---utils
+|   |       |   |               |           PermissionHelper.kt
+|   |       |   |               |           rememberWindowInfo.kt
+|   |       |   |               |           UiHelper.kt
+|   |       |   |               |           ViewModelFactoryHelper.kt
+|   |       |   |               |           
+|   |       |   |               \---utils
+|   |       |   |                       PreferencesManager.kt
+|   |       |   |                       Utils.kt
+|   |       |   |                       
+|   |       |   +---proto
+|   |       |   |       message.proto
+|   |       |   |       
+|   |       |   \---res
+|   |       |       +---drawable
+|   |       |       |       ic_launcher_foreground.xml
+|   |       |       |       ic_launcher_monochrome.xml
+|   |       |       |       
+|   |       |       +---drawable-v24
+|   |       |       |       ic_launcher_background.xml
+|   |       |       |       
+|   |       |       +---mipmap-anydpi-v26
+|   |       |       |       ic_launcher.xml
+|   |       |       |       ic_launcher_round.xml
+|   |       |       |       
+|   |       |       +---mipmap-hdpi
+|   |       |       |       ic_launcher.png
+|   |       |       |       ic_launcher_round.png
+|   |       |       |       
+|   |       |       +---mipmap-mdpi
+|   |       |       |       ic_launcher.png
+|   |       |       |       ic_launcher_round.png
+|   |       |       |       
+|   |       |       +---mipmap-xhdpi
+|   |       |       |       ic_launcher.png
+|   |       |       |       ic_launcher_round.png
+|   |       |       |       
+|   |       |       +---mipmap-xxhdpi
+|   |       |       |       ic_launcher.png
+|   |       |       |       ic_launcher_round.png
+|   |       |       |       
+|   |       |       +---mipmap-xxxhdpi
+|   |       |       |       ic_launcher.png
+|   |       |       |       ic_launcher_round.png
+|   |       |       |       
+|   |       |       +---values
+|   |       |       |       strings.xml
+|   |       |       |       themes.xml
+|   |       |       |       
+|   |       |       +---values-fr
+|   |       |       |       strings.xml
+|   |       |       |       
+|   |       |       \---xml
+|   |       |               accessory_filter.xml
+|   |       |               locales_config.xml
+|   |       |               
+|   |       +---releaseProto
+|   |       |   \---res
+|   |       |       \---values
+|   |       |               strings.xml
+|   |       |               
+|   |       \---releaseTesting
+|   |           \---res
+|   |               \---values
+|   |                       strings.xml
+|   |                       
+|   \---gradle
+|       |   libs.versions.toml
+|       |   
+|       \---wrapper
+|               gradle-wrapper.jar
+|               gradle-wrapper.properties
+|               
++---Assets
+|       icon.ico
+|       microphone-3404243_640.png
+|       p1.png
+|       p2.png
+|       p3.png
+|       p4.png
+|       p5.png
+|       README.md
+|       sound_config1.png
+|       sound_config2.png
+|       sound_config3.png
+|       sound_config4.png
+|       sound_config5.png
+|       sound_config6.png
+|       
+\---RustApp
+    |   .gitattributes
+    |   .gitignore
+    |   build.rs
+    |   Cargo.lock
+    |   Cargo.toml
+    |   i18n.toml
+    |   io.github.teamclouday.android-mic.json
+    |   justfile
+    |   README.md
+    |   rust-toolchain.toml
+    |   
+    +---.cargo
+    |       config.toml
+    |       
+    +---i18n
+    |   +---en
+    |   |       android_mic.ftl
+    |   |       
+    |   \---fr
+    |           android_mic.ftl
+    |           
+    +---res
+    |   +---icons
+    |   |       refresh24.svg
+    |   |       
+    |   +---linux
+    |   |       app_icon.svg
+    |   |       desktop_entry.desktop
+    |   |       metainfo.xml
+    |   |       
+    |   \---windows
+    |           app_icon.ico
+    |           
+    \---src
+        |   app.rs
+        |   audio.rs
+        |   config.rs
+        |   icon.rs
+        |   localize.rs
+        |   main.rs
+        |   map_bytes.rs
+        |   message.rs
+        |   start_at_login.rs
+        |   utils.rs
+        |   view.rs
+        |   
+        +---proto
+        |       message.proto
+        |       
+        +---streamer
+        |       adb_streamer.rs
+        |       message.rs
+        |       mod.rs
+        |       streamer_sub.rs
+        |       tcp_streamer.rs
+        |       udp_streamer.rs
+        |       usb_streamer.rs
+        |       
+        \---usb
+                aoa.rs
+                frame.rs
+                mod.rs
+                


### PR DESCRIPTION
This PR adds functionality to automatically build binaries directly within the GitHub repository using the Actions tab. The release.yml workflow will be triggered whenever a new tag prefixed with v is pushed.

Usage:
1. Create a new version tag locally:
    ```shell
    git tag -a "v2.1.0" -m "Version 2.1.0 released"
    ```
  
2. Push the tag to the remote repository:
    ```shell
    git push origin v2.1.0
    ```
Once the tag is pushed, GitHub Actions will:

- Build binaries for multiple platforms.
- Create a release draft with the generated binaries.

You can then review, edit, and publish the release directly from the Releases page.

Also added Project_Tree.txt to help new developers quickly understand the project's structure and file organization.