### PR TITLE
fix for f-droid

### DIFF
--- a/Android/app/build.gradle.kts
+++ b/Android/app/build.gradle.kts
@@ -75,6 +75,13 @@ android {
         checkReleaseBuilds = false
     }
 
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
+
 //    packaging {
 //        resources.excludes.add("google/protobuf/*.proto")
 //    }


### PR DESCRIPTION
see this comment https://gitlab.com/fdroid/fdroiddata/-/merge_requests/23911#note_2628588467.

Also, in a comment above, it is asked why we use a debug key to sign release build.
I think it's better to use a proper key (i'm also wondering how the debug key work in the first place, since it's supposed to be machine dependent, maybe github workflows are "unique")
if you want to setup this, you can use my app as a "template"
- https://github.com/wiiznokes/gitnote/blob/49127c0245bd3647ee5aacad1c72d82c7d8cf321/app/build.gradle.kts#L93
- https://github.com/wiiznokes/gitnote/blob/49127c0245bd3647ee5aacad1c72d82c7d8cf321/.github/workflows/release.yml#L52

<img width="1492" height="820" alt="Capture d’écran du 2025-07-16 02-36-17" src="https://github.com/user-attachments/assets/92a030aa-10cb-41de-83c4-8326bd749bf1" />
