### PR TITLE
add Simplified Chinese for desktop app

### DIFF
--- a/RustApp/i18n/en/android_mic.ftl
+++ b/RustApp/i18n/en/android_mic.ftl
@@ -1,17 +1,50 @@
 audio_device = Audio Device
 settings = Settings
+network_adapter = Network adapter
 connection = Connection
+connection_tcp = WIFI / LAN (TCP)
+connection_udp = WIFI / LAN (UDP)
+connection_usb = USB Serial
+connection_adb = USB Adb
 none = None
+
+tray_show_window = Show Window
+tray_connect = Connect
+tray_disconnect = Disconnect
+tray_exit = Exit
+minimized_to_tray = Application is minimized to system tray
+
+state_disconnected = Disconnected
+state_listening = Listening
+state_connected = Connected
 
 connect = Connect
 listening = Listening...
 disconnect = Disconnect
 waiting = Waiting...
 
+title_audio_format = Audio format
 sample_rate = Sample rate
 channel_count = Channel count
 audio_format = Audio format
+use_recommended_audio_format = Use Recommended Audio Format
+
 denoise = Noise reduction
+denoise_enabled = Enabled
+denoise_type = Type
+
+voice_activity_detection = Voice Activity Detection (VAD)
+voice_activity_detection_enabled = Enabled
+
+gain_control = Gain Control
+auto_gain_control = Automatic Gain Control (AGC)
+
+dereverberation = Dereverberation
+dereverberation_enabled = Enabled
+
+reset_denoise_settings = Reset Denoise Settings
+
+title_app = App
 
 start_at_login = Start at login
 auto_connect = Auto connect
@@ -19,6 +52,7 @@ theme = Theme
 amplify = Amplify
 
 about = About
+about_open = open
 repository = Repository
 issues_tracker = Report an Issue
 

--- a/RustApp/i18n/zh-CN/android_mic.ftl
+++ b/RustApp/i18n/zh-CN/android_mic.ftl
@@ -1,0 +1,71 @@
+audio_device = 音频设备
+settings = 设置
+network_adapter = 网络适配器
+connection = 建立连接
+connection_tcp = WIFI / 局域网 (TCP)
+connection_udp = WIFI / 局域网 (UDP)
+connection_usb = USB 串口
+connection_adb = USB Adb
+none = 无
+
+tray_show_window = 显示窗口
+tray_connect = 连接
+tray_disconnect = 断开连接
+tray_exit = 退出
+minimized_to_tray = 应用程序已最小化到系统托盘
+
+state_disconnected = 已断开连接
+state_listening = 正在监听
+state_connected = 已连接
+
+connect = 连接
+listening = 正在监听...
+disconnect = 断开连接
+waiting = 正在等待...
+
+title_audio_format = 音频格式
+sample_rate = 采样率
+channel_count = 通道数量
+audio_format = 音频格式
+use_recommended_audio_format = 使用推荐的音频格式
+
+denoise = 降噪
+denoise_enabled = 启用
+denoise_type = 类型
+
+voice_activity_detection = 语音活动检测 (VAD)
+voice_activity_detection_enabled = 启用
+
+gain_control = 增益控制
+auto_gain_control = 自动增益控制 (AGC)
+
+dereverberation = 去混响
+dereverberation_enabled = 启用
+
+reset_denoise_settings = 重置降噪设置
+
+title_app = 应用程序
+
+start_at_login = 开机启动
+auto_connect = 自动连接
+theme = 主题
+amplify = 放大
+
+about = 关于
+about_open = 打开
+repository = 开源仓库
+issues_tracker = 报告问题
+
+main_window_title = AndroidMic
+settings_window_title = 设置
+
+system_theme = 跟随系统
+dark_theme = 暗色
+light_theme = 亮色
+hight_contrast_dark_theme = 高对比度暗色
+hight_contrast_light_theme = 高对比度亮色
+
+mono = 单声道
+stereo = 立体声
+
+clear_logs = 清空日志

--- a/RustApp/src/ui/app.rs
+++ b/RustApp/src/ui/app.rs
@@ -232,7 +232,7 @@ impl AppState {
         self.audio_wave.clear();
 
         if let Some(system_tray) = self.system_tray.as_mut() {
-            system_tray.update_menu_state(true, "Disconnected");
+            system_tray.update_menu_state(true, &fl!("state_disconnected"));
         }
 
         Task::none()
@@ -321,7 +321,7 @@ impl Application for AppState {
         // initialize system tray
         let (system_tray, system_tray_stream) = match SystemTray::new() {
             Ok((mut tray, stream)) => {
-                tray.update_menu_state(true, "Disconnected");
+                tray.update_menu_state(true, &fl!("state_disconnected"));
                 (Some(tray), Some(stream))
             }
             Err(e) => {
@@ -419,7 +419,7 @@ impl Application for AppState {
                 }
                 StreamerMsg::Listening { ip, port } => {
                     if let Some(system_tray) = self.system_tray.as_mut() {
-                        system_tray.update_menu_state(false, "Listening");
+                        system_tray.update_menu_state(false, &fl!("state_listening"));
                     }
 
                     if self.main_window.is_none() {
@@ -447,7 +447,7 @@ impl Application for AppState {
                 }
                 StreamerMsg::Connected { ip, port } => {
                     if let Some(system_tray) = self.system_tray.as_mut() {
-                        system_tray.update_menu_state(false, "Connected");
+                        system_tray.update_menu_state(false, &fl!("state_connected"));
                     }
 
                     if self.main_window.is_none() {
@@ -679,7 +679,7 @@ impl Application for AppState {
 
                 let _ = Notification::new()
                     .summary("AndroidMic")
-                    .body("Application is minimized to system tray")
+                    .body(&fl!("minimized_to_tray"))
                     .auto_icon()
                     .show()
                     .map_err(|e| {

--- a/RustApp/src/ui/tray.rs
+++ b/RustApp/src/ui/tray.rs
@@ -7,7 +7,7 @@ use tray_icon::{
     menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
 };
 
-use crate::tray_icon;
+use crate::{fl, tray_icon};
 
 #[derive(Debug, Clone)]
 pub enum SystemTrayMsg {
@@ -30,10 +30,10 @@ pub struct SystemTray {
 
 impl SystemTray {
     pub fn new() -> anyhow::Result<(Self, SystemTrayStream)> {
-        let item_show = MenuItem::new("Show Window", true, None);
-        let item_connect = MenuItem::new("Connect", true, None);
-        let item_disconnect = MenuItem::new("Disconnect", true, None);
-        let item_exit = MenuItem::new("Exit", true, None);
+        let item_show = MenuItem::new(fl!("tray_show_window"), true, None);
+        let item_connect = MenuItem::new(fl!("tray_connect"), true, None);
+        let item_disconnect = MenuItem::new(fl!("tray_disconnect"), true, None);
+        let item_exit = MenuItem::new(fl!("tray_exit"), true, None);
 
         let item_show_id = item_show.id().clone();
         let item_connect_id = item_connect.id().clone();

--- a/RustApp/src/ui/view.rs
+++ b/RustApp/src/ui/view.rs
@@ -134,7 +134,7 @@ fn network_adapter(app: &AppState) -> Element<'_, AppMsg> {
     column()
         .spacing(20)
         .align_x(Horizontal::Center)
-        .push(text::title4("Network Adapter"))
+        .push(text::title4(fl!("network_adapter")))
         .push(
             row()
                 .width(Length::Fill)
@@ -168,13 +168,13 @@ fn connection_type(app: &AppState) -> Element<'_, AppMsg> {
         .push(
             column()
                 .push(radio(
-                    "WIFI / LAN (TCP)",
+                    text(fl!("connection_tcp")),
                     &ConnectionMode::Tcp,
                     Some(connection_mode),
                     |mode| AppMsg::ChangeConnectionMode(*mode),
                 ))
                 .push(radio(
-                    "WIFI / LAN (UDP)",
+                    text(fl!("connection_udp")),
                     &ConnectionMode::Udp,
                     Some(connection_mode),
                     |mode| AppMsg::ChangeConnectionMode(*mode),
@@ -183,7 +183,7 @@ fn connection_type(app: &AppState) -> Element<'_, AppMsg> {
                     #[cfg(feature = "usb")]
                     {
                         Some(radio(
-                            "USB Serial",
+                            text(fl!("connection_usb")),
                             &ConnectionMode::Usb,
                             Some(connection_mode),
                             |mode| AppMsg::ChangeConnectionMode(*mode),
@@ -199,7 +199,7 @@ fn connection_type(app: &AppState) -> Element<'_, AppMsg> {
                     #[cfg(feature = "adb")]
                     {
                         Some(radio(
-                            "USB Adb",
+                            text(fl!("connection_adb")),
                             &ConnectionMode::Adb,
                             Some(connection_mode),
                             |mode| AppMsg::ChangeConnectionMode(*mode),
@@ -235,7 +235,7 @@ pub fn settings_window(app: &AppState) -> Element<'_, ConfigMsg> {
             .spacing(20)
             .push(
                 settings::section()
-                    .title("Audio format")
+                    .title(fl!("title_audio_format"))
                     .add(
                         row()
                             .align_y(Vertical::Center)
@@ -273,7 +273,7 @@ pub fn settings_window(app: &AppState) -> Element<'_, ConfigMsg> {
                         row()
                             .push(horizontal_space())
                             .push(
-                                button::text("Use Recommended Audio Format")
+                                button::text(fl!("use_recommended_audio_format"))
                                     .on_press(ConfigMsg::UseRecommendedFormat),
                             )
                             .push(horizontal_space()),
@@ -285,14 +285,14 @@ pub fn settings_window(app: &AppState) -> Element<'_, ConfigMsg> {
                     .add(
                         row()
                             .align_y(Vertical::Center)
-                            .push(text("Enabled"))
+                            .push(text(fl!("denoise_enabled")))
                             .push(horizontal_space())
                             .push(toggler(config.denoise).on_toggle(ConfigMsg::DeNoise)),
                     )
                     .add_maybe((config.denoise).then(|| {
                         row()
                             .align_y(Vertical::Center)
-                            .push(text("Type"))
+                            .push(text(fl!("denoise_type")))
                             .push(horizontal_space())
                             .push(pick_list(
                                 DenoiseKind::VALUES,
@@ -321,11 +321,11 @@ pub fn settings_window(app: &AppState) -> Element<'_, ConfigMsg> {
             )
             .push(
                 settings::section()
-                    .title("Voice Activity Detection (VAD)")
+                    .title(fl!("voice_activity_detection"))
                     .add(
                         row()
                             .align_y(Vertical::Center)
-                            .push(text("Enabled"))
+                            .push(text(fl!("voice_activity_detection_enabled")))
                             .push(horizontal_space())
                             .push(
                                 toggler(config.speex_vad_enabled)
@@ -349,11 +349,11 @@ pub fn settings_window(app: &AppState) -> Element<'_, ConfigMsg> {
             )
             .push(
                 settings::section()
-                    .title("Gain Control")
+                    .title(fl!("gain_control"))
                     .add(
                         row()
                             .align_y(Vertical::Center)
-                            .push(text("Automatic Gain Control (AGC)"))
+                            .push(text(fl!("auto_gain_control")))
                             .push(horizontal_space())
                             .push(
                                 toggler(config.speex_agc_enabled)
@@ -398,11 +398,11 @@ pub fn settings_window(app: &AppState) -> Element<'_, ConfigMsg> {
             )
             .push(
                 settings::section()
-                    .title("Dereverberation")
+                    .title(fl!("dereverberation"))
                     .add(
                         row()
                             .align_y(Vertical::Center)
-                            .push(text("Enabled"))
+                            .push(text(fl!("dereverberation_enabled")))
                             .push(horizontal_space())
                             .push(
                                 toggler(config.speex_dereverb_enabled)
@@ -424,10 +424,10 @@ pub fn settings_window(app: &AppState) -> Element<'_, ConfigMsg> {
                             )
                     })),
             )
-            .push(button::text("Reset Denoise Settings").on_press(ConfigMsg::ResetDenoiseSettings))
+            .push(button::text(fl!("reset_denoise_settings")).on_press(ConfigMsg::ResetDenoiseSettings))
             .push(
                 settings::section()
-                    .title("App")
+                    .title(fl!("title_app"))
                     .add_maybe(if cfg!(target_os = "windows") {
                         Some(
                             row()
@@ -462,7 +462,7 @@ pub fn settings_window(app: &AppState) -> Element<'_, ConfigMsg> {
                     )
                     .add(
                         widget::settings::item::builder(fl!("about"))
-                            .control(button::text("open").on_press(ConfigMsg::ToggleAboutWindow)),
+                            .control(button::text(fl!("about_open")).on_press(ConfigMsg::ToggleAboutWindow)),
                     ),
             ),
     )


### PR DESCRIPTION
And also move some hard-encoded text into i18n properties. I know nothing for French so there is no changes on `fr`.