### PR TITLE
Exclude system tray feature on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         if: matrix.platform == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libjack-jackd2-dev libxkbcommon-dev protobuf-compiler libgtk-3-dev libxdo-dev libappindicator3-dev
+          sudo apt-get install -y libasound2-dev libjack-jackd2-dev libxkbcommon-dev protobuf-compiler
 
       - name: Install dependencies (Windows)
         if: matrix.platform == 'windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         if: matrix.platform == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libjack-jackd2-dev libxkbcommon-dev protobuf-compiler libgtk-3-dev libxdo-dev libappindicator3-dev
+          sudo apt-get install -y libasound2-dev libjack-jackd2-dev libxkbcommon-dev protobuf-compiler
 
       - name: Install dependencies (Windows)
         if: matrix.platform == 'windows'

--- a/RustApp/Cargo.toml
+++ b/RustApp/Cargo.toml
@@ -86,7 +86,6 @@ libcosmic = { git = "https://github.com/pop-os/libcosmic.git", rev = "8412dd5939
     "highlighter",
     "about",
 ] }
-tray-icon = "0.21.1"
 notify-rust = "4"
 byteorder = "1"
 nusb = { version = "0.1", optional = true }
@@ -112,6 +111,9 @@ mslnk = "0.1"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1"
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+tray-icon = "0.21.1"
 
 # [patch."https://github.com/pop-os/libcosmic.git"]
 # libcosmic = { path = "../../libcosmic" }

--- a/RustApp/src/ui/app.rs
+++ b/RustApp/src/ui/app.rs
@@ -136,6 +136,7 @@ pub struct AppState {
     log_path: String,
     pub system_tray: Option<SystemTray>,
     pub system_tray_stream: Option<SystemTrayStream>,
+    has_shown_minimize_notification: bool,
 }
 
 pub struct CustomWindow {
@@ -363,6 +364,7 @@ impl Application for AppState {
             log_path: flags.log_path.clone(),
             system_tray,
             system_tray_stream,
+            has_shown_minimize_notification: false,
         };
 
         commands.push(
@@ -677,14 +679,17 @@ impl Application for AppState {
                     self.about_window = None;
                 }
 
-                let _ = Notification::new()
-                    .summary("AndroidMic")
-                    .body(&fl!("minimized_to_tray"))
-                    .auto_icon()
-                    .show()
-                    .map_err(|e| {
-                        error!("failed to show notification: {e}");
-                    });
+                if !self.has_shown_minimize_notification {
+                    let _ = Notification::new()
+                        .summary("AndroidMic")
+                        .body(&fl!("minimized_to_tray"))
+                        .auto_icon()
+                        .show()
+                        .map_err(|e| {
+                            error!("failed to show notification: {e}");
+                        });
+                    self.has_shown_minimize_notification = true;
+                }
 
                 return cosmic::iced_runtime::Task::batch(effects);
             }

--- a/RustApp/src/ui/app.rs
+++ b/RustApp/src/ui/app.rs
@@ -708,25 +708,35 @@ impl Application for AppState {
             }
             AppMsg::SystemTray(tray_msg) => match tray_msg {
                 SystemTrayMsg::Show => {
-                    let settings = window::Settings {
-                        size: Size::new(800.0, 600.0),
-                        position: window::Position::Centered,
-                        icon: window_icon!("icon"),
-                        ..Default::default()
-                    };
-
-                    let (new_id, command) = cosmic::iced::window::open(settings);
-                    self.main_window = Some(CustomWindow { window_id: new_id });
-                    let set_window_title = self.set_window_title(fl!("main_window_title"), new_id);
-
-                    return command
-                        .map(|_| cosmic::action::Action::None)
-                        .chain(set_window_title)
-                        .chain(cosmic::iced_runtime::task::effect(
+                    if let Some(main_window) = &self.main_window {
+                        // avoid duplicate window
+                        return cosmic::iced_runtime::task::effect(
                             cosmic::iced::runtime::Action::Window(window::Action::GainFocus(
-                                new_id,
+                                main_window.window_id,
                             )),
-                        ));
+                        );
+                    } else {
+                        let settings = window::Settings {
+                            size: Size::new(800.0, 600.0),
+                            position: window::Position::Centered,
+                            icon: window_icon!("icon"),
+                            ..Default::default()
+                        };
+
+                        let (new_id, command) = cosmic::iced::window::open(settings);
+                        self.main_window = Some(CustomWindow { window_id: new_id });
+                        let set_window_title =
+                            self.set_window_title(fl!("main_window_title"), new_id);
+
+                        return command
+                            .map(|_| cosmic::action::Action::None)
+                            .chain(set_window_title)
+                            .chain(cosmic::iced_runtime::task::effect(
+                                cosmic::iced::runtime::Action::Window(window::Action::GainFocus(
+                                    new_id,
+                                )),
+                            ));
+                    }
                 }
                 SystemTrayMsg::Exit => {
                     return cosmic::iced_runtime::task::effect(cosmic::iced::runtime::Action::Exit);

--- a/RustApp/src/ui/icon.rs
+++ b/RustApp/src/ui/icon.rs
@@ -73,10 +73,3 @@ macro_rules! tray_icon {
     }};
     ($name:literal) => {{ tray_icon!($name, 32, 32) }};
 }
-
-// placeholder here
-#[cfg(target_os = "linux")]
-#[macro_export]
-macro_rules! tray_icon {
-    () => {};
-}

--- a/RustApp/src/ui/icon.rs
+++ b/RustApp/src/ui/icon.rs
@@ -48,6 +48,7 @@ macro_rules! window_icon {
     ($name:literal) => {{ window_icon!($name, 32, 32) }};
 }
 
+#[cfg(not(target_os = "linux"))]
 #[macro_export]
 macro_rules! tray_icon {
     ($name:literal, $width:expr, $height:expr) => {{
@@ -71,4 +72,11 @@ macro_rules! tray_icon {
         tray_icon::Icon::from_rgba(rgba, $width, $height)
     }};
     ($name:literal) => {{ tray_icon!($name, 32, 32) }};
+}
+
+// placeholder here
+#[cfg(target_os = "linux")]
+#[macro_export]
+macro_rules! tray_icon {
+    () => {};
 }

--- a/RustApp/src/ui/tray.rs
+++ b/RustApp/src/ui/tray.rs
@@ -9,6 +9,7 @@ use tray_icon::{
     menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
 };
 
+#[cfg(not(target_os = "linux"))]
 use crate::{fl, tray_icon};
 
 #[derive(Debug, Clone)]

--- a/RustApp/src/ui/tray.rs
+++ b/RustApp/src/ui/tray.rs
@@ -2,6 +2,8 @@ use cosmic::iced::{futures::Stream, stream};
 use futures::SinkExt;
 use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
+
+#[cfg(not(target_os = "linux"))]
 use tray_icon::{
     TrayIcon, TrayIconBuilder, TrayIconEvent,
     menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
@@ -22,13 +24,18 @@ pub struct SystemTrayStream {
     receiver: Arc<Mutex<mpsc::UnboundedReceiver<SystemTrayMsg>>>,
 }
 
+#[cfg(not(target_os = "linux"))]
 pub struct SystemTray {
     tray_icon: TrayIcon,
     item_connect: MenuItem,
     item_disconnect: MenuItem,
 }
 
+#[cfg(target_os = "linux")]
+pub struct SystemTray;
+
 impl SystemTray {
+    #[cfg(not(target_os = "linux"))]
     pub fn new() -> anyhow::Result<(Self, SystemTrayStream)> {
         let item_show = MenuItem::new(fl!("tray_show_window"), true, None);
         let item_connect = MenuItem::new(fl!("tray_connect"), true, None);
@@ -88,6 +95,19 @@ impl SystemTray {
         ))
     }
 
+    #[cfg(target_os = "linux")]
+    pub fn new() -> anyhow::Result<(Self, SystemTrayStream)> {
+        // placeholder here
+        let (_sender, receiver) = mpsc::unbounded_channel();
+        Ok((
+            Self {},
+            SystemTrayStream {
+                receiver: Arc::new(Mutex::new(receiver)),
+            },
+        ))
+    }
+
+    #[cfg(not(target_os = "linux"))]
     pub fn update_menu_state(&mut self, disconnected: bool, status: &str) {
         // update menu item states
         self.item_connect.set_enabled(disconnected);
@@ -98,6 +118,11 @@ impl SystemTray {
             .map_err(|e| {
                 error!("failed to set tray icon tooltip: {e}");
             });
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn update_menu_state(&mut self, _disconnected: bool, _status: &str) {
+        // placeholder here
     }
 }
 


### PR DESCRIPTION
See #103 
[tray-icon](https://github.com/tauri-apps/tray-icon) is unstable on Linux
Exclude the feature for now. Add back once gtk4 is supported by tray-icon