### PR TITLE
opti audio stream function

### DIFF
--- a/RustApp/Cargo.lock
+++ b/RustApp/Cargo.lock
@@ -142,6 +142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +218,7 @@ dependencies = [
  "clap 4.5.56",
  "constcat",
  "cpal",
+ "criterion",
  "directories",
  "either",
  "enum_dispatch",
@@ -231,6 +241,7 @@ dependencies = [
  "open",
  "prost",
  "prost-build",
+ "rand 0.10.1",
  "resvg 0.46.0",
  "rtrb",
  "rubato",
@@ -261,6 +272,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -1071,6 +1088,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1149,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1171,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1593,6 +1654,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,10 +1672,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap 4.5.56",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2775,8 +2899,22 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -3583,6 +3721,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4013,6 +4157,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libappindicator"
@@ -5077,6 +5227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5150,6 +5306,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser 0.25.1",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5426,6 +5592,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
@@ -5775,6 +5969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5793,6 +5993,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5834,6 +6045,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "range-alloc"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5850,6 +6067,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "read-fonts"
@@ -6420,7 +6657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6431,7 +6668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -7021,6 +7258,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7549,6 +7796,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7608,6 +7864,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-timer"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7620,6 +7898,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
 ]
 
 [[package]]
@@ -8617,6 +8907,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.114",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/RustApp/Cargo.lock
+++ b/RustApp/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "i18n-embed",
  "i18n-embed-fl",
  "interprocess",
+ "itertools 0.14.0",
  "libcosmic",
  "light_enum",
  "local-ip-address",

--- a/RustApp/Cargo.toml
+++ b/RustApp/Cargo.toml
@@ -124,3 +124,12 @@ tray-icon = "0.21.1"
 
 # [patch."https://github.com/wiiznokes/speexdsp-rs-fork"]
 # speexdsp = { path = "../../speexdsp-rs-fork" }
+
+
+[dev-dependencies]
+criterion = "0.8"
+rand = "0.10"
+
+[[bench]]
+name = "audio"
+harness = false

--- a/RustApp/Cargo.toml
+++ b/RustApp/Cargo.toml
@@ -104,6 +104,7 @@ speexdsp = { git = "https://github.com/wiiznokes/speexdsp-rs-fork", branch = "he
 fslock = "0.2"
 interprocess = { version = "2", features = ["tokio"] }
 async-stream = "0.3"
+itertools = "0.14"
 
 [build-dependencies]
 prost-build = "0.14"

--- a/RustApp/benches/audio.rs
+++ b/RustApp/benches/audio.rs
@@ -1,0 +1,43 @@
+use std::io::Write;
+
+use android_mic::audio::player::process_audio;
+use criterion::{Criterion, criterion_group, criterion_main};
+use rtrb::{Producer, RingBuffer};
+
+fn make_random(size: usize) -> Vec<u8> {
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    let mut rng = StdRng::seed_from_u64(42);
+
+    let mut v = vec![0; size];
+
+    rng.fill_bytes(&mut v);
+    v
+}
+
+fn feed_producer(producer: &mut Producer<u8>, src: &[u8]) {
+    producer.write(src).unwrap();
+}
+
+fn bench_audio(c: &mut Criterion) {
+    c.bench_function("audio_processing", |b| {
+        let shared_buffer_size = 48000 * 2;
+
+        let (mut producer, mut consumer) = RingBuffer::<u8>::new(shared_buffer_size);
+
+        // pre-fill fake audio buffer
+        let mut output = vec![0i16; 480 * 2];
+
+        let source = make_random(48000);
+
+        b.iter(|| {
+            feed_producer(&mut producer, &source);
+
+            process_audio::<i16>(&mut output, &mut consumer, 480);
+        });
+    });
+}
+
+criterion_group!(benches, bench_audio);
+criterion_main!(benches);

--- a/RustApp/src/audio/mod.rs
+++ b/RustApp/src/audio/mod.rs
@@ -103,7 +103,7 @@ impl AppState {
 }
 
 pub trait AudioBytes {
-    fn from_bytes(bytes: &[u8]) -> Option<Self>
+    fn from_bytes(bytes: &[u8]) -> Self
     where
         Self: Sized;
 
@@ -123,15 +123,11 @@ pub trait AudioBytes {
 }
 
 impl AudioBytes for i16 {
-    fn from_bytes(bytes: &[u8]) -> Option<Self>
+    fn from_bytes(bytes: &[u8]) -> Self
     where
         Self: Sized,
     {
-        if bytes.len() == 2 {
-            Some(NativeEndian::read_i16(bytes))
-        } else {
-            None
-        }
+        NativeEndian::read_i16(bytes)
     }
 
     fn to_bytes(&self) -> Vec<u8> {
@@ -158,15 +154,11 @@ impl AudioBytes for i16 {
 }
 
 impl AudioBytes for i32 {
-    fn from_bytes(bytes: &[u8]) -> Option<Self>
+    fn from_bytes(bytes: &[u8]) -> Self
     where
         Self: Sized,
     {
-        if bytes.len() == 4 {
-            Some(NativeEndian::read_i32(bytes))
-        } else {
-            None
-        }
+        NativeEndian::read_i32(bytes)
     }
 
     fn to_bytes(&self) -> Vec<u8> {
@@ -193,18 +185,18 @@ impl AudioBytes for i32 {
 }
 
 impl AudioBytes for f32 {
-    fn from_bytes(bytes: &[u8]) -> Option<Self>
+    fn from_bytes(bytes: &[u8]) -> Self
     where
         Self: Sized,
     {
         if bytes.len() == 3 {
             // 3 bytes for i24 format
             let val = NativeEndian::read_i24(bytes);
-            Some(val as f32 / (1 << 23) as f32)
+            val as f32 / (1 << 23) as f32
         } else if bytes.len() == 4 {
-            Some(NativeEndian::read_f32(bytes))
+            NativeEndian::read_f32(bytes)
         } else {
-            None
+            unreachable!()
         }
     }
 
@@ -232,15 +224,11 @@ impl AudioBytes for f32 {
 }
 
 impl AudioBytes for u8 {
-    fn from_bytes(bytes: &[u8]) -> Option<Self>
+    fn from_bytes(bytes: &[u8]) -> Self
     where
         Self: Sized,
     {
-        if bytes.len() == 1 {
-            Some(bytes[0])
-        } else {
-            None
-        }
+        bytes[0]
     }
 
     fn to_bytes(&self) -> Vec<u8> {
@@ -265,15 +253,11 @@ impl AudioBytes for u8 {
 }
 
 impl AudioBytes for u32 {
-    fn from_bytes(bytes: &[u8]) -> Option<Self>
+    fn from_bytes(bytes: &[u8]) -> Self
     where
         Self: Sized,
     {
-        if bytes.len() == 4 {
-            Some(NativeEndian::read_u32(bytes))
-        } else {
-            None
-        }
+        NativeEndian::read_u32(bytes)
     }
 
     fn to_bytes(&self) -> Vec<u8> {

--- a/RustApp/src/audio/mod.rs
+++ b/RustApp/src/audio/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 mod denoise_rnnoise;
-mod player;
+pub mod player;
 mod postprocessing;
 pub mod process;
 mod resampler;

--- a/RustApp/src/audio/mod.rs
+++ b/RustApp/src/audio/mod.rs
@@ -196,7 +196,7 @@ impl AudioBytes for f32 {
         } else if bytes.len() == 4 {
             NativeEndian::read_f32(bytes)
         } else {
-            unreachable!()
+            panic!()
         }
     }
 

--- a/RustApp/src/audio/player.rs
+++ b/RustApp/src/audio/player.rs
@@ -75,42 +75,61 @@ fn build_output_stream<F>(
     mut consumer: Consumer<u8>,
 ) -> anyhow::Result<cpal::Stream, cpal::BuildStreamError>
 where
-    F: cpal::SizedSample + AudioBytes + std::fmt::Debug + 'static,
+    F: cpal::SizedSample + AudioBytes + 'static,
 {
+    let frame_size = std::mem::size_of::<F>();
+    let channels = config.channels as usize;
+    let frame_bytes = frame_size * channels;
+
     device.build_output_stream(
         &config,
         move |data: &mut [F], _| {
-            // read data from the consumer
-            let data_size = std::mem::size_of_val(data);
-            match consumer.read_chunk(data_size) {
-                Ok(chunk) => {
-                    let samples = chunk
-                        .into_iter()
-                        .collect::<Vec<_>>()
-                        .chunks_exact(std::mem::size_of::<F>())
-                        .map(|chunk| F::from_bytes(chunk).unwrap())
-                        .collect::<Vec<_>>();
-                    let len = data.len();
-                    data[..len].copy_from_slice(&samples[..len]);
-                }
-                Err(ChunkError::TooFewSlots(slots)) => {
-                    if slots == 0 {
-                        return;
-                    }
+            let byte_len = data.len() * frame_size;
 
-                    let data_size =
-                        slots - (slots % (std::mem::size_of::<F>() * config.channels as usize));
-                    let chunk = consumer.read_chunk(data_size).unwrap();
-                    let samples = chunk
-                        .into_iter()
-                        .collect::<Vec<_>>()
-                        .chunks_exact(std::mem::size_of::<F>())
-                        .map(|chunk| F::from_bytes(chunk).unwrap())
-                        .collect::<Vec<_>>();
-                    let len = samples.len().min(data.len());
-                    data[..len].copy_from_slice(&samples[..len]);
+            let chunk = match consumer.read_chunk(byte_len) {
+                Ok(c) => c,
+                Err(ChunkError::TooFewSlots(slots)) if slots > 0 => {
+                    let aligned = slots - (slots % frame_bytes);
+                    match consumer.read_chunk(aligned) {
+                        Ok(c) => c,
+                        Err(_) => return,
+                    }
                 }
+                _ => return,
+            };
+
+            let (chunk1, mut chunk2) = chunk.as_slices();
+
+            let chunk1_iter = chunk1.chunks_exact(frame_size);
+
+            // handle case if a frame is split in chunk1 and chunk2.
+            // this will probably never happens tho
+            let mid_part = if chunk1_iter.remainder().len() != 0 {
+                let (right_part, chunk2_) =
+                    chunk2.split_at(frame_size - chunk1_iter.remainder().len());
+
+                chunk2 = chunk2_;
+
+                let mut v = Vec::with_capacity(frame_size);
+
+                v.extend(chunk1_iter.remainder());
+                v.extend(right_part);
+
+                itertools::Either::Left(std::iter::once(F::from_bytes(&v)))
+            } else {
+                itertools::Either::Right(std::iter::empty())
+            };
+
+            let samples = chunk1_iter
+                .map(|b| F::from_bytes(b))
+                .chain(mid_part)
+                .chain(chunk2.chunks_exact(frame_size).map(|b| F::from_bytes(b)));
+
+            for (out, sample) in data.iter_mut().zip(samples) {
+                *out = sample;
             }
+
+            chunk.commit_all();
         },
         |err| error!("an error occurred on audio stream: {err}"),
         None,

--- a/RustApp/src/audio/player.rs
+++ b/RustApp/src/audio/player.rs
@@ -69,6 +69,59 @@ pub fn create_audio_stream(
     Ok((stream, config))
 }
 
+pub fn process_audio<F>(data: &mut [F], consumer: &mut Consumer<u8>, frame_bytes: usize)
+where
+    F: cpal::SizedSample + AudioBytes,
+{
+    let frame_size = std::mem::size_of::<F>();
+
+    let byte_len = std::mem::size_of_val(data);
+
+    let chunk = match consumer.read_chunk(byte_len) {
+        Ok(c) => c,
+        Err(ChunkError::TooFewSlots(slots)) if slots > 0 => {
+            let aligned = slots - (slots % frame_bytes);
+            match consumer.read_chunk(aligned) {
+                Ok(c) => c,
+                Err(_) => return,
+            }
+        }
+        _ => return,
+    };
+
+    let (chunk1, mut chunk2) = chunk.as_slices();
+
+    let chunk1_iter = chunk1.chunks_exact(frame_size);
+
+    // handle case if a frame is split in chunk1 and chunk2.
+    // this will probably never happens tho
+    let mid_part = if !chunk1_iter.remainder().is_empty() {
+        let (right_part, chunk2_) = chunk2.split_at(frame_size - chunk1_iter.remainder().len());
+
+        chunk2 = chunk2_;
+
+        let mut v = Vec::with_capacity(frame_size);
+
+        v.extend(chunk1_iter.remainder());
+        v.extend(right_part);
+
+        itertools::Either::Left(std::iter::once(F::from_bytes(&v)))
+    } else {
+        itertools::Either::Right(std::iter::empty())
+    };
+
+    let samples = chunk1_iter
+        .map(|b| F::from_bytes(b))
+        .chain(mid_part)
+        .chain(chunk2.chunks_exact(frame_size).map(|b| F::from_bytes(b)));
+
+    for (out, sample) in data.iter_mut().zip(samples) {
+        *out = sample;
+    }
+
+    chunk.commit_all();
+}
+
 fn build_output_stream<F>(
     device: &cpal::Device,
     config: cpal::StreamConfig,
@@ -84,52 +137,7 @@ where
     device.build_output_stream(
         &config,
         move |data: &mut [F], _| {
-            let byte_len = data.len() * frame_size;
-
-            let chunk = match consumer.read_chunk(byte_len) {
-                Ok(c) => c,
-                Err(ChunkError::TooFewSlots(slots)) if slots > 0 => {
-                    let aligned = slots - (slots % frame_bytes);
-                    match consumer.read_chunk(aligned) {
-                        Ok(c) => c,
-                        Err(_) => return,
-                    }
-                }
-                _ => return,
-            };
-
-            let (chunk1, mut chunk2) = chunk.as_slices();
-
-            let chunk1_iter = chunk1.chunks_exact(frame_size);
-
-            // handle case if a frame is split in chunk1 and chunk2.
-            // this will probably never happens tho
-            let mid_part = if chunk1_iter.remainder().len() != 0 {
-                let (right_part, chunk2_) =
-                    chunk2.split_at(frame_size - chunk1_iter.remainder().len());
-
-                chunk2 = chunk2_;
-
-                let mut v = Vec::with_capacity(frame_size);
-
-                v.extend(chunk1_iter.remainder());
-                v.extend(right_part);
-
-                itertools::Either::Left(std::iter::once(F::from_bytes(&v)))
-            } else {
-                itertools::Either::Right(std::iter::empty())
-            };
-
-            let samples = chunk1_iter
-                .map(|b| F::from_bytes(b))
-                .chain(mid_part)
-                .chain(chunk2.chunks_exact(frame_size).map(|b| F::from_bytes(b)));
-
-            for (out, sample) in data.iter_mut().zip(samples) {
-                *out = sample;
-            }
-
-            chunk.commit_all();
+            process_audio(data, &mut consumer, frame_bytes);
         },
         |err| error!("an error occurred on audio stream: {err}"),
         None,

--- a/RustApp/src/audio/process.rs
+++ b/RustApp/src/audio/process.rs
@@ -230,7 +230,7 @@ where
         for channel in 0..channel_count {
             let start = channel * audio_format.sample_size();
             let end = start + audio_format.sample_size();
-            let sample = F::from_bytes(&buf[start..end]).unwrap().to_f32();
+            let sample = F::from_bytes(&buf[start..end]).to_f32();
             result[channel].push(sample);
         }
     }
@@ -266,14 +266,12 @@ where
     {
         if channel_count == 1 {
             // For mono, there's just one sample
-            result.push(F::from_bytes(buf).unwrap().to_f32());
+            result.push(F::from_bytes(buf).to_f32());
         } else {
             // For stereo, we merge the two samples into one
             let left = F::from_bytes(&buf[0..audio_format.sample_size()])
-                .unwrap()
                 .to_f32();
             let right = F::from_bytes(&buf[audio_format.sample_size()..])
-                .unwrap()
                 .to_f32();
 
             result.push((left + right) / 2.0); // Mix the two channels

--- a/RustApp/src/audio/process.rs
+++ b/RustApp/src/audio/process.rs
@@ -269,10 +269,8 @@ where
             result.push(F::from_bytes(buf).to_f32());
         } else {
             // For stereo, we merge the two samples into one
-            let left = F::from_bytes(&buf[0..audio_format.sample_size()])
-                .to_f32();
-            let right = F::from_bytes(&buf[audio_format.sample_size()..])
-                .to_f32();
+            let left = F::from_bytes(&buf[0..audio_format.sample_size()]).to_f32();
+            let right = F::from_bytes(&buf[audio_format.sample_size()..]).to_f32();
 
             result.push((left + right) / 2.0); // Mix the two channels
         }

--- a/RustApp/src/lib.rs
+++ b/RustApp/src/lib.rs
@@ -1,0 +1,13 @@
+#[macro_use]
+extern crate log;
+
+pub mod audio;
+pub mod config;
+pub mod single_instance;
+pub mod start_at_login;
+pub mod streamer;
+pub mod ui;
+pub mod utils;
+
+#[macro_use]
+pub mod localize;

--- a/RustApp/src/main.rs
+++ b/RustApp/src/main.rs
@@ -1,33 +1,23 @@
 // to not launch a console on Windows, only in release because it blocks all logs
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use android_mic::{localize, single_instance};
 use chrono::Local;
 use std::io::Write;
 use std::{fs::File, path::Path};
 
+use android_mic::config::{Args, Config};
+use android_mic::ui::app::run_ui;
+use android_mic::utils::{self, APP, ORG, QUALIFIER};
 use clap::Parser;
-use config::{Args, Config};
 use directories::ProjectDirs;
 use fslock::LockFile;
-use ui::app::run_ui;
-use utils::{APP, ORG, QUALIFIER};
 use zconf::ConfigManager;
 
-use crate::ui::app::Flags;
+use android_mic::ui::app::Flags;
 
 #[macro_use]
 extern crate log;
-
-mod audio;
-mod config;
-mod single_instance;
-mod start_at_login;
-mod streamer;
-mod ui;
-mod utils;
-
-#[macro_use]
-mod localize;
 
 struct DualWriter {
     file: Box<File>,


### PR DESCRIPTION
Avoid two allocation in the audio stream function

- chunk is a wrapper over 2 slices (a view over the circular buffer), so we can use those instead of allocating a vector
  ```rs
  chunk
                          .into_iter()
                          .collect::<Vec<_>>()
                          .chunks_exact(std::mem::size_of::<F>())
  ```
- we collect the sample in a buffer, and then write to the audio buffer. We can avoid this and directly write to the audio buffer

I've not benchmarked my changes tho
