### PR TITLE
[codex] Clear stale output samples on underrun

### DIFF
--- a/RustApp/src/audio/player.rs
+++ b/RustApp/src/audio/player.rs
@@ -73,6 +73,8 @@ pub fn process_audio<F>(data: &mut [F], consumer: &mut Consumer<u8>, frame_bytes
 where
     F: cpal::SizedSample + AudioBytes,
 {
+    data.fill(F::from_f32(0.0));
+
     let frame_size = std::mem::size_of::<F>();
 
     let byte_len = std::mem::size_of_val(data);
@@ -142,4 +144,39 @@ where
         |err| error!("an error occurred on audio stream: {err}"),
         None,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use rtrb::RingBuffer;
+
+    use super::*;
+
+    fn i16_samples_to_bytes(samples: &[i16]) -> Vec<u8> {
+        samples.iter().flat_map(AudioBytes::to_bytes).collect()
+    }
+
+    #[test]
+    fn process_audio_silences_output_when_buffer_is_empty() {
+        let (_producer, mut consumer) = RingBuffer::<u8>::new(16);
+        let mut output = [123_i16, -456, 789, -111];
+
+        process_audio(&mut output, &mut consumer, std::mem::size_of::<i16>());
+
+        assert_eq!(output, [0; 4]);
+    }
+
+    #[test]
+    fn process_audio_zero_fills_after_partial_read() {
+        let (mut producer, mut consumer) = RingBuffer::<u8>::new(16);
+        let input = i16_samples_to_bytes(&[1000, -2000]);
+        producer.write_all(&input).unwrap();
+
+        let mut output = [55_i16, 55, 55, 55];
+        process_audio(&mut output, &mut consumer, std::mem::size_of::<i16>());
+
+        assert_eq!(output, [1000, -2000, 0, 0]);
+    }
 }


### PR DESCRIPTION
## What changed

- zero-fill the CPAL output buffer before copying samples from the ring buffer
- add regression tests for empty-buffer and partial-buffer underrun cases
- drop the unrelated RNNoise, Speex, resampler, and shared-buffer tuning from this fix

## Why

This issue was caused by `process_audio` leaving part or all of the output slice untouched when the ring buffer did not have enough bytes for a full callback. In those underrun paths, CPAL reused whatever values were already present in `data`, which replayed stale samples and sounded like duplicated audio.

The fix is to treat underruns as silence by default and then overwrite only the samples we actually received.

## Impact

- full underruns now output silence instead of stale audio
- partial underruns preserve the valid samples and zero-fill the remainder of the callback buffer
- the change is limited to the output callback path and is easy to revert if needed

## Validation

- `cargo fmt --check`
- `cargo clippy --lib --tests --all-features -- -D warnings`
- `cargo test --lib --all-features`
- `cargo check --lib --tests --all-features`
- `cargo build --lib --tests --all-features`

## Notes

Repository-wide `cargo clippy --all-targets --all-features -- -D warnings` still reports an existing `benches/audio.rs` warning unrelated to this patch.
