### PR TITLE
Fix PipeWire issue in AppImage

### DIFF
--- a/RustApp/Cargo.toml
+++ b/RustApp/Cargo.toml
@@ -31,6 +31,9 @@ installer_mode = "both"
 entitlements = "res/macos/entitlements.plist"
 info_plist_path = "res/macos/Info.plist"
 
+[package.metadata.packager.appimage]
+excluded_libraries = ["libpipewire*"]
+
 [lints.rust]
 dead_code = "allow"
 unexpected_cfgs = { level = "warn", check-cfg = [


### PR DESCRIPTION
AppImage includes its own libpipewire which conflicts with the system PipeWire library. As a result, the program doesn't see PipeWire output devices. I fixed it by removing this library from the AppImage.